### PR TITLE
[master]: Changes for new 6.16.z branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.16.z'
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
@@ -23,6 +24,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.16.z'
       - "CherryPick"
       - "dependencies"
       - "6.15.z"

--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           # Use GitHub API to check if the user triggering the workflow is a member of satellite-admin group
           MEMBER=$(curl -s -H "Authorization: token ${{ secrets._REPO_ADMIN_TOKEN }}" \
-              "https://api.github.com/orgs/satelliteQE/teams/repository-admins/memberships/${{ github.actor }}")
+              "https://api.github.com/orgs/satelliteQE/teams/repository-admins/memberships/jyejare")
           if [[ $(echo "$MEMBER" | jq -r '.state') == "active" ]]; then
             echo "User is a member of satellite-admin group."
             echo "member=true" >> $GITHUB_OUTPUT

--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -15,7 +15,7 @@ ROBOTTELO:
   RUN_ONE_DATAPOINT: false
   # Satellite version supported by this branch
   # UNDR version is used for some URL composition
-  SATELLITE_VERSION: "6.16"
+  SATELLITE_VERSION: "6.17"
   # The Base OS RHEL Version(x.y) where the satellite would be installed
   RHEL_VERSION: "8.9"
   # Dynaconf and Dynaconf hooks related options

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -16,9 +16,9 @@ class Colored(Box):
 
 
 # This should be updated after each version branch
-SATELLITE_VERSION = "6.16"
+SATELLITE_VERSION = "6.17"
 SATELLITE_OS_VERSION = "8"
-SAT_NON_GA_VERSIONS = ['6.15', '6.16']
+SAT_NON_GA_VERSIONS = ['6.16', '6.17']
 
 # Default system ports
 HTTPS_PORT = '443'

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -43,7 +43,6 @@ from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
     ],
     indirect=True,
 )
-@pytest.mark.stream
 def test_positive_content_counts_for_mixed_cv(
     target_sat,
     module_capsule_configured,
@@ -179,7 +178,6 @@ def test_positive_content_counts_for_mixed_cv(
     assert len(info['lifecycle-environments']) == 0, 'The LCE is still listed'
 
 
-@pytest.mark.stream
 def test_positive_update_counts(target_sat, module_capsule_configured):
     """Verify the update counts functionality
 


### PR DESCRIPTION

  ### Problem Statement
  New 6.16.z downstream and master points to stream that is 6.17
  ### Solution
  - Dependabot.yaml cherrypicks to 6.16.z
  - Robottelo conf and constants now uses 6.17 and 6.16.z satellite versions
